### PR TITLE
Added a fragment to the welcome

### DIFF
--- a/content/welcome.md
+++ b/content/welcome.md
@@ -3,6 +3,7 @@
 Welcome to CodeZero!
 
 [whatiscodezero](_fragments/whatiscodezero.md ':include')
+[codezeroisos](_fragments/codezeroisos.md ':include')
 
 Our [Quick Start Guide](/welcome/quickstart.md) guide is a great place to start if you want to jump right into getting your clouds installed and applications running.
 


### PR DESCRIPTION
Added a fragment that describes code zero as an operating system that you install so that when you get to the welcome page after signing up you know explicitly what to do next.

I think if we then have one call to action the first time you log in and don't have any "MyClouds". That call to action should be to install the operating system that is CodeZero into your cloud. This perspective can be taken by both business and developer user personas. 

After the first cloud install, a second call to action should be manifest to either act as a developer and create an app or as a non-developer user to browse the marketplace.

Perhaps as the user installs the O/S, we can figure out if they are a developer or non-developer and bring up the righ call to action as they get their first CodeZero "Operating System to the Cloud" running.