### PR TITLE
Added description of the provisioning manifest

### DIFF
--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -39,7 +39,7 @@ spec:
 
 ### Fields
 
-These are standard k8s metadata fields and how they are used by c6o
+These are standard k8s metadata fields and how they are used by CodeZero (c6o)
 
 | Name      | Description                                  |
 |-----------|----------------------------------------------|

--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -44,7 +44,7 @@ These are standard k8s metadata fields and how they are used by CodeZero (c6o)
 | Name      | Description                                  |
 |-----------|----------------------------------------------|
 | name      | Globally unique application name             |
-| namespace | Namespace where the application is installed. This is used to distinguish your application components from other developer's applications |
+| namespace | Namespace where the application is installed. This is a logical parittion used to distinguish your application from other developer's applications |
 | finalizers | set to `finalizer.app.codezero.io` after install |
 
 ### Labels

--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -1,6 +1,6 @@
 # Application Spec Reference
 
-The CodeZero Application's *Provisioning Manifest*, or *Custom Resource Definition* (CRD) is used by CodeZero to configure applications and provide information to the CodeZero apps for display. This will be part of creating and uploading your application package when creating an application in the CodeZero Hub. 
+The CodeZero Application's *Provisioning Manifest* is a Kubernetes *Custom Resource Definition* (CRD) and is used by CodeZero to configure applications and provide information to the CodeZero apps for display. This will be part of creating and uploading your application package when creating an application in the CodeZero Hub. 
 
 The provisioning system uses all of the fields in this manifest to deploy your application. There are two top level sections: 
 * *metadata* used to describe your application to the CodeZero interfaces

--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -6,7 +6,7 @@ The provisioning system uses all of the fields in this manifest to deploy your a
 * *metadata* used to describe your application to the CodeZero interfaces
 * *spec* used to describe your application's provisioning behaviour, networking and storage configuration.
 
-Within the metadata and spec sections, there are three sub-sections each. For metadata, the sub-sections are *fields*, *labels* and *annotations*. For the spec, the sub-sections are *routes*, *provisioner* and *marina*. Understanding the provisioning manifest will llow you to control your deployment and setup the CodeZero cloud operating system to automagically deploy your application for end users.
+Within the metadata and spec sections, there are three sub-sections each. For metadata, the sub-sections are *fields*, *labels* and *annotations*. For the spec, the sub-sections are *routes*, *provisioner* and *marina*. Understanding the provisioning manifest will allow you to control your deployment and setup the CodeZero cloud operating system to automagically deploy your application for end users.
 
 An example spec is shown below:
 

--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -44,7 +44,7 @@ These are standard k8s metadata fields and how they are used by CodeZero (c6o)
 | Name      | Description                                  |
 |-----------|----------------------------------------------|
 | name      | Globally unique application name             |
-| namespace | Namespace where the application is installed |
+| namespace | Namespace where the application is installed. This is used to distinguish your application components from other developer's applications |
 | finalizers | set to `finalizer.app.codezero.io` after install |
 
 ### Labels

--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -1,8 +1,12 @@
 # Application Spec Reference
 
-The CodeZero Application Custom Resource Definition (CRD) is used by CodeZero to configure applications and provide information to the CodeZero apps for display.
+The CodeZero Application's *Provisioning Manifest*, or *Custom Resource Definition* (CRD) is used by CodeZero to configure applications and provide information to the CodeZero apps for display. This will be part of creating and uploading your application package when creating an application in the CodeZero Hub. 
 
-The system uses the application metadata fields, labels, and annotations as well as content in the `spec` section
+The provisioning system uses all of the fields in this manifest to deploy your application. There are two top level sections: 
+* *metadata* used to describe your application to the CodeZero interfaces
+* *spec* used to describe your application's provisioning behaviour, networking and storage configuration.
+
+Within the metadata and spec sections, there are three sub-sections each. For metadata, the sub-sections are *fields*, *labels* and *annotations*. For the spec, the sub-sections are *routes*, *provisioner* and *marina*. Understanding the provisioning manifest will llow you to control your deployment and setup the CodeZero cloud operating system to automagically deploy your application for end users.
 
 An example spec is shown below:
 

--- a/content/reference/appspec.md
+++ b/content/reference/appspec.md
@@ -44,7 +44,7 @@ These are standard k8s metadata fields and how they are used by CodeZero (c6o)
 | Name      | Description                                  |
 |-----------|----------------------------------------------|
 | name      | Globally unique application name             |
-| namespace | Namespace where the application is installed. This is a logical parittion used to distinguish your application from other developer's applications |
+| namespace | Namespace where the application is installed. This is a logical parittion used to establish a location within a user's marina. (Your application manifest will be templated so that the provisioner can create the script to install into a particular user specified namespace). |
 | finalizers | set to `finalizer.app.codezero.io` after install |
 
 ### Labels


### PR DESCRIPTION
Added description of the contents of the provisioning manifest. 

Clarifies why I should be interested, the fact that what is described below are fields not other files and the general target of the manifest within CodeZero.
