### PR TITLE
chore(appengine): Update getting started guides to new AppEngine spec

### DIFF
--- a/content/_fragments/cli-install.md
+++ b/content/_fragments/cli-install.md
@@ -1,6 +1,6 @@
 ```bash
-sudo npm install -g @c6o/cli --unsafe-perm=true
+sudo npm install -g @c6o/cli
 ```
 
 > [!WIP]
-> '--unsafe-perm' is currently required to allow the dependency 'keytar' to build successfully.
+> Yarn fails to install the @c6o/cli, so please use npm for now.

--- a/content/_fragments/cli-requirements.md
+++ b/content/_fragments/cli-requirements.md
@@ -1,3 +1,2 @@
 * NPM (Version 6.14+)
 * Node (Version 12.16+)
-* Linux requires "libsecret-1-dev" (On Ubuntu run `sudo apt-get install libsecret-1-dev`)

--- a/content/concepts/applications.md
+++ b/content/concepts/applications.md
@@ -1,6 +1,6 @@
 # A CodeZero Application
 
-An Application in the CodeZero ecosystem consists of 3 main components.  First off, there is the core application itself, which can be developed in any number of ways, so long as it is executable in a container environment.  Then there is the CodeZero Provisioner, which is responsible for orchestrating the installation and management of your application in an end-users cluster.  And lastly, there is an Application Manifest that describes the application in the CodeZero ecosystem.
+An Application in the CodeZero ecosystem consists of 3 main components.  First off, there is the core application itself, which can be developed in many ways, so long as it is executable in a container environment.  Then there is the CodeZero Provisioner, responsible for orchestrating the installation and management of your application in an end-users cluster.  Lastly, there is an Application Manifest that describes the application in the CodeZero ecosystem.
 
 ## Components
 
@@ -21,9 +21,9 @@ graph TD
     IMAGE -.-> |published to| DOCKER[(Docker Hub)]
 ```
 
-### Containerized Image
+### Container Image
 
-A container image represents binary data that encapsulates your application and all its software dependencies.  CodeZero supports any containerized technology that Kubernetes supports (for example: Docker, containerd, CRI-O).  However, for simplicity, we will focus our documentation and support on applications using Docker and published to Docker Hub.
+A container image represents binary data that encapsulates your application and all its software dependencies.  CodeZero supports any container technology that runs on Kubernetes (for example, Docker, containerd, CRI-O).  However, we focus our documentation on applications published to Docker Hub for simplicity.
 
 > [!NOTE]
 > Checkout the [Hello World Guide](../guides/hello-world) for an example of creating an application from scratch and publishing through Docker Hub.
@@ -39,40 +39,38 @@ Therefore, instead of trying to explain all of this ourselves, we will just cove
 
 ### Provisioner
 
-A Provisioner is an NPM package used by the CodeZero platform to install, remove, and reconfigure applications.  In this regard, it is similar Helm.  However, CodeZero provides several important features that improve on existing tools:
+A Provisioner is an NPM package used by the CodeZero platform to install, remove, and reconfigure applications.  In this regard, it is similar Helm.  However, CodeZero provides several essential features that improve on existing tools:
 
 1. User-friendly UI: allow both technical and non-technical audiences to install and manage your applications with ease
-1. Not just a template: take control the provisioning processes using JavaScript/NodeJS.
+1. Not just a template: take control of the provisioning processes using JavaScript/NodeJS.
 1. Powerful API: the CodeZero provisioner API for powerful and flexible application management.
-
-Once a provisioner is created, it can be accessed by the CLI or from within the CodeZero desktop UI in order to create and manage the application.
 
 #### App Engine
 
-App Engine is a highly configurable provisioner created by CodeZero that provides developers with a fast and easy way to onboard their applications without needing to create a customer provisioner of their own.
+App Engine is a highly configurable provisioner created by CodeZero that provides developers with a fast and easy way to onboard their applications without creating a customer provisioner of their own.
 
 > [!NOTE]
-> Check out the [Creating a Basic Application Guide](../guide/appengine) to see App Engine in action.
+> Check out the [Creating a Basic Application Guide](../guides/appengine.md) to see App Engine in action.
 
 > [!EXPERT]
-> Check out the [App Engine reference](../references/appengine) for a full list of App Engine features and configuration.
+> Check out the [App Engine reference](../references/appengine.md) for a full list of App Engine features and configuration.
 
 #### Provisioner API
 
-If your application requires more advanced customization, you can create your own provisioner package, and leverage the full power of our Provisioner API.
+If an application requires advanced customization not supported by App Engine, create a custom provisioner package to leverage our Provisioner API's full power.
 
 > [!NOTE]
-> Check out the [Creating a Custom Provisioner](../guide/custom-provisioner) to see App Engine in action.
+> Check out the [Creating a Custom Provisioner](../guides/custom-provisioner.md) to see how to create a Custom Provisioner.
 
 > [!EXPERT]
-> Check out the [Provisioner API documentation](../references/provisioner) for more advanced features.
+> Check out the [Provisioner API documentation](../references/provisioner.md) to learn about the provisioner APIs.
 
 ### Application Manifest
 
-The Application Manifest describes how an Application behaves in the CodeZero ecosystem.  It includes all the metadata needed to display an application in the Marketplace (ex: the applications name, description, icon, category, tags, etc).  It also defines the provisioner responsible for installing and managing the application, how the user interacts with the application (ex: what happens when the user clicks on the icon on their desktop), and how/what to expose to the outside world.
+The Application Manifest describes how an Application behaves in the CodeZero ecosystem.  It includes all the metadata needed to display an application in the Marketplace (ex: the applications name, description, icon, category, tags, etc), defines the provisioner responsible for installing and managing the application, describes how the user interacts with the application (ex: what happens when the user clicks on the icon on their desktop), and how/what to expose to the outside world.
 
 > [!NOTE]
-> Check out the [Creating a Basic Application Guide](../guide/appengine) to see what a basic Application Manifest looks like.
+> Check out the [Creating a Basic Application Guide](../guides/appengine.md) to see how basic Application Manifest looks.
 
 > [!EXPERT]
 > See [here](../references/application-manifest) for a full description of the Application Manifest and all its properties.
@@ -81,11 +79,11 @@ The Application Manifest describes how an Application behaves in the CodeZero ec
 
 ### Guides
 
-We have created a few walkthrough guides to help get you started with publishing an application on CodeZero:
+These walkthrough guides should get you started with publishing an application on CodeZero:
 
 1. [Hello World Example](../guides/hello-world)
 1. [Publishing a Standard Application](../guides/appengine)
-1. [Creating a Custom Provisioner](../guides/custom-provisioner) 
+1. [Creating a Custom Provisioner](../guides/custom-provisioner)
 
 ### Monetize your Application
 

--- a/content/guides/appengine.md
+++ b/content/guides/appengine.md
@@ -5,12 +5,12 @@
 
 In this guide, we walk through the steps to publish a standard application to CodeZero.  By the end of this guide, you will create and publish a provisioner for [NodeRED](https://nodered.org/) to the CodeZero marketplace.
 
-## Prerequisits
+## Prerequisites
 
 You'll need to:
 
-1. setup a [CodeZero Cluster](https://docs.docker.com/engine/install/), and
-1. install and configure the [CodeZero CLI](https://nodejs.org/en/),
+1. setup a [CodeZero Cluster](./getting-started.md#Install-CodeZero), and
+1. install and configure the [CodeZero CLI](./getting-started.md#Install-CLI),
 
 ## Getting Started
 
@@ -25,41 +25,38 @@ As with all CodeZero applications, there are three main components we need to co
 
 ## The Containerized Application
 
-The first component we need for any CodeZero Application is a containerized application.  In this guide, we will use [NodeRED](https://nodered.org/) as an example, which the community has already created and published a docker hub image for us ([nodered/node-red](https://hub.docker.com/r/nodered/node-red)).
+The first component we need for any CodeZero Application is a containerized application.  In this guide, we use [NodeRED](https://nodered.org/) as an example.  The NodeRED community has already created and published a docker hub image for us ([nodered/node-red](https://hub.docker.com/r/nodered/node-red)).
 
 > [!EXPERT]
 > To learn how to create your own containerized applications, check out our [NodeJS Hello World](./hello-world) docker guide.
 
 ### Configuring NodeRED
 
-NodeRED is a simple web application that does not take much to configure.  There are just a few properties we will want to be aware of as we continue with setting up this application to run in CodeZero:
+NodeRED is a simple web application that does not take much to configure.  There are just a few properties we need to be aware of as we continue with setting up this application to run in CodeZero:
 
 1. **Application Port:**  NodeRED runs a basic web application on port `1880`.
 1. **Environment Variables:**  We can use the `NODE_RED_ENABLE_PROJECTS` environment variable to control whether NodeRED has [projects](https://nodered.org/docs/user-guide/projects/) enabled or disabled.
-1. **Persistent Data:**  NodeRED stores user data in the `/data` directory, which we will want to make sure gets persisted between container restarts/upgrades/etc.
+1. **Persistent Data:**  NodeRED stores user data in the `/data` directory, which we want to make sure gets persisted if the container ever restarts or moves.
 
 ## Application Provisioner
 
-The Application Provisioner is responsible for handling the installation and management of the application in a customer's CodeZero Cloud.  Instead of writing a full Provisioner yourself, CodeZero has built a highly configurable Provisioner called AppEngine (`@provisioner/appengine`) that provides more than enough flexibility to manage this NodeRED application.
+The "Application Provisioner" is a NodeJS package responsible for installing and managing the application in a customer's CodeZero Cloud.  Instead of writing a full Provisioner yourself, CodeZero has built a highly configurable Provisioner called AppEngine (`@provisioner/appengine`) that provides more than enough flexibility to manage this NodeRED application.
 
 > [!NOTE]
-> Check out the [App Engine documentation](../references/appengine) to learn more about App Engine.
+> Check out the [App Engine documentation](../references/appengine) to learn more about how App Engine.
 
 > [!EXPERT]
-> Learn how to create a custom provisioner with our [Custom Provisioner guide](./3-codegen.md).
+> Learn how to create a custom Provisioner with our [Custom Provisioner Guide](./custom-provisioner.md).
 
 ## Application Manifest
 
-The Application Manifest consists of a YAML file that describes our Application within the CodeZero ecosystem.  It may also contain additional asset files (ex: icons, images, etc).  This file can be named anything, recommended convention is to either have `c6o.yaml` in the root of your project, or place it in a folder at `c6o/app.yaml`;
-
-> [!NOTE]
-> Check out the [Application Manifest specification](../references/application-manifest.md) for a full list of properties and configurations.
+The Application Manifest consists of a YAML file that describes the application within the CodeZero ecosystem.  It may also contain additional asset files (ex: icons, images, etc).  This file can be named anything, however, the recommended convention is either have `c6o.yaml` in the root of your project or place it in a `c6o` folder (ex: `c6o/app.yaml`);
 
 ### Application Manifest Basics
 
-In this guide, we only need to create an Application Manifest, as we are using `@provisioner/appengine` and the docker image `nodered/node-red` for our provisioner and containerized application respectively.
+Since we are using `@provisioner/appengine` and the docker image `nodered/node-red` (Provisioner and application image, respectively), we only need to create an Application Manifest.
 
-So, let's first create a basic YAML file for our Application Manifest: `c6o.yaml`.
+So, let's first create a simple YAML file for our Application Manifest: `c6o.yaml`.
 
 ```yaml
 name: Node Red
@@ -82,26 +79,29 @@ editions:
       # Marina configuration goes here
 ```
 
+> [!NOTE]
+> Check out the [Application Manifest specification](../references/application-manifest.md) for a full list of properties and configurations.
+
 ### Edition
 
-The `editions` property contains an array of possible editions a customer can install.  Each edition has its own configuration and settings.  As a starting point, we only need one edition, which we will call "preview".
+The `editions` property contains an array of possible editions that an end-user can choose from.  Each edition has a set of configuration and settings.  As a starting point, we only need one edition, which we call "preview".
 
 > [!NOTE]
-> Learn more about what editions are for and how they should be used [here](../concepts/editions.md).
+> Learn more about what editions are for [here](../concepts/editions.md).
 
 > [!EXPERT]
 > For more details about how to use editions, checkout the [editions](../references/editions.md) reference.
 
 ### Provisioner Spec
 
-The `provisioner` property contains configuration settings that are specific to the provisioner project.  We are using the App Engine provisioner, so all properties here will be dictated by the `@provisioner/appengine` project.
+The `provisioner` property contains configuration settings that are specific to the provisioner project.  We are using the App Engine provisioner, so all properties here are related to the `@provisioner/appengine` project.
 
 > [!EXPERT]
 > For a full description of App Engine, checkout the [App Engine](../references/editions.md) documentation.
 
 #### App Engine Basics
 
-First, we need to define in our Application Manifest that we want to use the App Engine NPM package (`@provisioner/appengine`) as the underlying provisioner.  Next, we need to define the Docker Hub image (`nodered/node-red`) that we want App Engine to set up.
+First, we need to define the provisioner package to use during installation.  In this case, we are using App Engine NPM (`@provisioner/appengine`) as the applications underlying provisioner.  Additionally, we need to define the Docker Hub image (`nodered/node-red`) that we want App Engine to use.
 
 ```yaml
 #...
@@ -113,13 +113,11 @@ editions:
       package: @provisioner/appengine  # Provisioner NPM package
       name: nodered                    # Likely same as appId
       image: nodered/node-red          # Docker Hub image
-      automated: true                  # should always be true
-
 ```
 
 #### Environment Variables
 
-App Engine has the ability to define any number of environment variables.  We will enable the NodeRED projects feature using:
+App Engine can define any number of environment variables as a simple key-value pair.  We enable the NodeRED [projects feature](https://nodered.org/docs/user-guide/projects/) by adding:
 
 ```yaml
 #...
@@ -129,13 +127,12 @@ editions:
     # ...
     provisioner:
       configs:
-      - name: NODE_RED_ENABLE_PROJECTS
-        value: true
+        NODE_RED_ENABLE_PROJECTS: true
 ```
 
 #### Mounted Volumes
 
-In order to persist data stored at `/data`, the provisioner should create a persistent volume that is mounted at this path.  Persistent volumes are automatically provisioned with the customers cloud provider at the size specified, then mounted to container at the path specified.
+App Engine can create persistent volume claims and mount them to our applications using the `volumes` property.  To persist data stored at `/data`, we add to the Application Manifest:
 
 ```yaml
 #...
@@ -152,7 +149,7 @@ editions:
 
 #### Exposed Ports
 
-The NodeRED application image contains a web server running on port `1880`.  So we need to instruct Kubernetes that there is an HTTP service available on port `1880` of our application.
+The NodeRED application image contains a web server running on port `1880`.  So we need to instruct CodeZero (and in turn, Kubernetes) that there is an HTTP service available on port `1880` of our application.  App Engine does this by specifying the `ports` property.
 
 ```yaml
 #...
@@ -172,7 +169,7 @@ editions:
 
 ### Public Routes
 
-Above, we used App Engine to expose the NodeRED web server running on port `1880` within the cluster.  However, we need to use `routes` in order to expose our service to the outside world.
+Above, we used App Engine to expose the NodeRED web server running on port `1880` within the cluster.  If we want CodeZero to expose this route to the outside world, we add configuration to the Application Manifest's `routes`:
 
 ```yaml
 #...
@@ -182,16 +179,16 @@ editions:
     # ...
     routes:
     - type: http
-      targetService: nodered
+      targetService: nodered   # should match spec.provisioner.name
       targetPort: 1880
 ```
 
 > [!TIP]
-> The `targetPort` can be automatically configured if our application only exposes a single port (as is the case here), however we include it here for clarity.
+> The `targetPort` can be automatically detected if our application only exposes a single port (as is the case here), however, we include it here for clarity.
 
 ### Marina
 
-Lastly, once the application is up and running in your user's cluster.  The application will be added to their Marina (CodeZero desktop).  When the customer clicks on the NodeRED icon within their Marina, we want it to launch NodeRED in a new popup window.
+Lastly, once the application is up and running in your user's cluster.  The application displays in their Marina (CodeZero desktop).  When the customer clicks on the NodeRED icon within the Marina, we want it to launch NodeRED in a new popup window.
 
 To accomplish this, we use the `marina` property as follows:
 
@@ -204,7 +201,7 @@ editions:
     marina:
       launch:
         type: inline
-        popup: true
+        popUp: true
 ```
 
 ## Final Product
@@ -236,11 +233,9 @@ editions:
       package: '@provisioner/appengine'
       name: nodered
       image: nodered/node-red
-      automated: true
 
       configs:
-      - name: NODE_RED_ENABLE_PROJECTS
-        value: true
+        NODE_RED_ENABLE_PROJECTS: true
 
       ports:
       - port: 1880
@@ -251,28 +246,47 @@ editions:
         size: 5Gi
 ```
 
+## Test the Application
+
+To test the application, we instruct the CLI to install an application from a local manifest.
+
+```bash
+czctl install --local ./c6o.yaml
+```
+
+> [!NOTE]
+> You'll need to have your KUBECONFIG configured to work with the CLI.  See [here](./getting-started.md#Connect-to-your-Private-Cloud) for more details.
+
+> [!WIP]
+> The Marina does not display the application's icon correctly when an installation is performed locally like this.
+
 ## Publish the Application
+
+Once the application installs correctly, you are ready to publish to the CodeZero marketplace.
 
 ```bash
 czctl app publish ./c6o.yaml
 ```
 
-### Test the Application
+> [!NOTE]
+> You'll need to have your CLI authenticated with your CodeZero account.  See the [Getting Started Guide](../guides/getting-started#Connect-to-the-Hub-API) for more instructions.
 
-There are two ways to test installing your application:
+> [!PROTIP]
+> Change the edition's `scope` to `public` if you want other's to see and install your application from the Marketplace.
+
+### Verify the Application Published
+
+There are two ways to verify that the application is published correctly:
 
 1. Using the CLI
-1. Using the Store
-
-### From the Marketplace
-
-Navigate to the [Marketplace](https://codezero.io/marketplace), find your application, and begin the installation processes.
+1. Using the Marketplace
 
 ### Using the CLI
-
-> [!NOTE]
-> You will need the [CLI setup](./setup-cli) to connect with a CodeZero cluster using `KUBECONFIG`.
 
 ```bash
 czctl install <your username>/nodejs-hello-world
 ```
+
+### From the Marketplace
+
+Navigate to the [Marketplace](https://codezero.io/marketplace), find your application, and begin the installation processes using the Web UI.

--- a/content/guides/hello-world.md
+++ b/content/guides/hello-world.md
@@ -52,7 +52,7 @@ app.listen(PORT, HOST);
 console.log(`Running on http://${HOST}:${PORT}`);
 ```
 
-This will create a very basic web server running on port 8080.  The server will respond with "Hello World" when the root is requested.
+This creates a very basic webserver running on port 8080.  The server responds with "Hello World" when the root is requested.
 
 ### Test Your Application
 
@@ -61,11 +61,11 @@ npm install
 npm start
 ```
 
-Now checkout <http://localhost:8080/>, you should see "Hello World" in your browser!
+Now check out http://localhost:8080/, you should see "Hello World" in your browser!
 
 ## Create a Dockerfile
 
-Next, lets configure our application to run in a Docker container.  First create a file called `Dockerfile` (there is no file extension), with the contents:
+Next, to configure the application to run in a Docker container, create a file called `Dockerfile` (there is no file extension), with the contents:
 
 ```docker
 # Base docker image
@@ -96,16 +96,18 @@ npm-debug.log
 
 ### Build and Run in Docker
 
-With the Dockerfile created, we can now build and run our application in docker.
+With the Dockerfile created, we can build and run the application in Docker:
 
 ```bash
 docker build -t <your-docker-username>/nodejs-hello-world ./
 docker run -p 12345:8080 -d <your-docker-username>/nodejs-hello-world
 ```
 
-Navigate to <http://localhost:12345/>, our application is now containerized in Docker!
+Navigate to http://localhost:12345/ to verify the application is running in Docker!
 
 ### Publish to Docker Hub
+
+To make the container available publicly, publish the container to docker:
 
 ```bash
 docker login
@@ -114,7 +116,7 @@ docker push <your-docker-username>/nodejs-hello-world
 
 ## Application Manifest using AppEngine
 
-We need to create an Application Manifest in order to describe how our Application is defined and behaves in the CodeZero ecosystem.  We do this by creating a simple YAML file called `c6o.yaml`:
+To get the application into the CodeZero ecosystem, an Application Manifest describes how our application is defined and behaves.  We do this by creating a simple YAML file called `c6o.yaml`:
 
 ```yaml
 name: Hello World
@@ -131,29 +133,44 @@ editions:
       package: @provisioner/appengine           # Provision using App Engine
       name: hello-world                          # Likely same as appId
       image: <your-docker-username>/nodejs-hello-world # Docker Hub image
-      automated: true                           # should always be true
       ports:
       - port: 8080
         protocol: tcp
 
     routes:
     - type: http
-      targetService: hello-world
+      targetService: hello-world  # same as spec.provisioner.name
       targetPort: 8080
 
     marina:
       launch:
         type: inline
-        popup: true
+        popUp: true
 ```
 
 > [!NOTE]
-> Check out the [Public Application using AppEngine](./appengine) for a little more details about what these properties do.
+> Check out the [Public Application using AppEngine](./appengine) guide for a more thorough description of what these properties do.
 
 > [!EXPERT]
 > Check out the [Application Manifest specification](../references/application-manifest.md) and [App Engine references](../references/appengine) for a full list of properties and configurations.
 
+## Test the Application
+
+To test the application, we instruct the CLI to install an application from a local manifest.
+
+```bash
+czctl install --local ./c6o.yaml
+```
+
+> [!NOTE]
+> You'll need to have your KUBECONFIG configured to work with the CLI.  See [here](./getting-started.md#Connect-to-your-Private-Cloud) for more details.
+
+> [!WIP]
+> The Marina does not display the application's icon correctly when an installation is performed locally like this.
+
 ## Publish the Application
+
+Once the application installs correctly, you are ready to publish to the CodeZero marketplace.
 
 ```bash
 czctl app publish ./c6o.yaml
@@ -162,25 +179,25 @@ czctl app publish ./c6o.yaml
 > [!NOTE]
 > You'll need to have your CLI authenticated with your CodeZero account.  See the [Getting Started Guide](../guides/getting-started#Connect-to-the-Hub-API) for more instructions.
 
-## Test the Application
+> [!PROTIP]
+> Change the edition's `scope` to `public` if you want other's to see and install your application from the marketplace.
 
-There are two ways to install your application:
+### Verify the Application Published
+
+There are two ways to verify that the application is published correctly:
 
 1. Using the CLI
-1. Using the Store
-
-### From the Marketplace
-
-Navigate to the [Marketplace](https://codezero.io/marketplace), find your application, and begin the installation processes.
+1. Using the Marketplace
 
 ### Using the CLI
 
-> [!NOTE]
-> You will need the [CLI setup](./setup-cli) to connect with a CodeZero cluster using `KUBECONFIG`.
-
 ```bash
-czctl install <your-c6o-username>-hello-world
+czctl install <your username>/nodejs-hello-world
 ```
+
+### From the Marketplace
+
+Navigate to the [Marketplace](https://codezero.io/marketplace), find your application, and begin the installation processes using the Web UI.
 
 ## All Done
 

--- a/content/references/appengine.md
+++ b/content/references/appengine.md
@@ -3,19 +3,19 @@
 > [!WIP]
 > This document is still being developed and may be incomplete.
 
-App Engine is a highly configurable provisioner created by CodeZero that provides developers with a fast and easy way to onboard their applications without needing to create a customer provisioner of their own.
+App Engine is a highly configurable provisioner created by CodeZero that provides developers with a fast and easy way to onboard their applications without creating a customer provisioner of their own.
 
 > [!NOTE]
-> Check out the [Creating a Basic Application Guide](../guide/1-basic) to see App Engine in action.
+> Check out the [Creating a Basic Application Guide](../guides/appengine) to see App Engine in action.
 
 ## When to use App Engine
 
 App Engine supports the most common application use-cases. It is ideal for any application that:
 
-1. Is contained in a single docker image,
-2. Exposes any number of TCP or HTTP endpoints,
-3. Is configurable using Environment variables, and
-4. Only requires standard user interaction/input during installation.
+1. is contained in a single docker image,
+2. exposes any number of TCP or HTTP endpoints,
+3. configurable using Environment variables, and
+4. only requires standard user interaction/input during installation.
 
 ### Not supported
 
@@ -74,7 +74,7 @@ editions:
 Configs are a KeyValue pair to define environment variables for the application.  The value is either a string or object of type [Generator](#Generator).
 
 > [!NOTE]
-> If the variable value contains sensitive information (ex: passwords, keys, etc), then use the [secrets](#Secret) property instead.
+> If the variable value contains sensitive information (ex: passwords, keys, tokens), then use the [secrets](#Secret) property instead.
 
 Several reserved values have special meaning.  If the value matches one of these reserved values, it is replaced at run-time by the appropriate value:
 

--- a/content/references/containers.md
+++ b/content/references/containers.md
@@ -9,41 +9,25 @@ Creating a Containerized Application consists of two primary steps:
 1. Creating a Container Image
 
 > [!NOTE]
-> Check out this [NodeJS Hello World](../guide/0.5-docker.md) guide to see this in action.
+> Check out this [NodeJS Hello World](../guides/hello-world) guide to see this in action.
 
 ## Creating an Application
 
-The application itself can developed in pretty much any language and environment that meets your needs best. Essentially anything that can execute in a Linux environment will work.  This is a very broad topic that is neither new or specific to CodeZero.
-
-Therefore, we cannot go into all variations of how to create the base application.
+The application itself can be developed in pretty much any language and environment that meets your needs best. Virtually anything that can execute in a Linux environment works with CodeZero.  This is an extensive topic that is neither new nor specific to CodeZero.  Therefore, instead of explaining all of this ourselves, we cover the basics and provide helpful links to learn more.
 
 ## Container Image
 
-A container image represents binary data that encapsulates your application and all its software dependencies.  Typically a container image of your application is published to a registry before referring to it in a Pod.
+A container image represents binary data that encapsulates your application and all its software dependencies.  Typically, your application's container image is published to a registry before referring to it in a Pod.
 
 ### Multiple Images
 
-One CodeZero application may consist of one or multiple container images, especially if the application is using a microservice architecture.
+One CodeZero application may consist of one or multiple container images.
 
-If an application has external dependencies (ex: database), it's highly recommended to use application linking rather than bundling applications together.  For example, if building a Wordpress provisioner, it may be tempting to directly include a MySQL container. However, a much better design should define the MySQL service as a dependency, so it can leverage the power of existing MySQL instances.
-
-How to develop the actual application logic that will run in a customers cluster is a very broad topic, and is not new or specific to CodeZero.
-
-Therefore, instead of trying to explain all of this ourselves, we will just cover the basics, and provide  some helpful links to learn more.
+If an application has external dependencies (ex: database), we recommend application linking rather than bundling applications together.  For example, when releasing a Wordpress provisioner, it may be tempting to include a MySQL container directly. However, a much better design should define the MySQL service as a dependency to leverage the power of existing MySQL instances.
 
 ## Types of Containers
 
-CodeZero supports any containerized technology that Kubernetes supports (for example: Docker, containerd, CRI-O).  However, for simplicity, we will focus on applications that have been containerized in docker.
-
-## Application Binaries
-
-Developing the application code that will be running on a customers cluster is a very broad topic, and is not in anyway specific to CodeZero.  Therefore, instead of trying to explain all of this ourselves, we include some helpful links below for how to get started.
-
-## Getting Started
-
-The simplest way to get started with CodeZero application development, is to first get familiar with the provisioner processes using an existing docker hub image.
-
-See our NodeRED 
+CodeZero supports any containerized technology that Kubernetes supports (for example: Docker, containerd, CRI-O).  However, for simplicity, we focus on applications that are containerized in Docker.
 
 ## Helpful Links
 


### PR DESCRIPTION
## Description

Grammar and spec changes for getting started guides.  Also fixes some broken links.

Fixes #42 #43 