### PR TITLE
fix: Update links to the Desktop app webpage

### DIFF
--- a/apps/concepts/applications.md
+++ b/apps/concepts/applications.md
@@ -30,7 +30,7 @@ A container image represents binary data that encapsulates your application and 
 
 <!-- ### Multiple Images
 
-A CodeZero Application may consist of one or multiple container images. However, if an application has external dependencies (ex: database), it's highly recommended to use application linking rather than bundling applications together. 
+A CodeZero Application may consist of one or multiple container images. However, if an application has external dependencies (ex: database), it's highly recommended to use application linking rather than bundling applications together.
 For example, if building a Wordpress provisioner, it may be tempting to directly include a MySQL container. However, a much better design should define the MySQL service as a dependency, so it can leverage the power of existing MySQL instances.
 
 How to develop the actual application logic that will run in a customers cluster is a very broad topic, and is not new or specific to CodeZero.
@@ -39,11 +39,11 @@ Therefore, instead of trying to explain all of this ourselves, we will just cove
 
 ### Provisioner
 
-A Provisioner is an NPM package used by the CodeZero platform to install, remove, and reconfigure applications. In this regard, it is similar Helm. However, CodeZero provides several essential features that improve on existing tools:
+A Provisioner is an NPM package used by CodeZero to install, remove, and reconfigure applications. In this regard, it is similar Helm. However, CodeZero provides several essential features that improve on existing tools:
 
 1. User-friendly UI: allow both technical and non-technical audiences to install and manage your applications with ease
-1. Not just a template: take control of the provisioning processes using JavaScript/NodeJS.
-1. Powerful API: the CodeZero provisioner API for powerful and flexible application management.
+2. Not just a template: take control of the provisioning processes using JavaScript/NodeJS.
+3. Powerful API: the CodeZero provisioner API for powerful and flexible application management.
 
 #### App Engine
 

--- a/content/_fragments/app-install.md
+++ b/content/_fragments/app-install.md
@@ -1,4 +1,4 @@
-To install the full desktop application, visit our [downloads page](https://codezero.io/platform/desktop#download-app), and install the appropriate installer for your Operating System.
+To install the full desktop application, visit our [downloads page](https://codezero.io/tooling/desktop#download-app), and install the appropriate installer for your Operating System.
 
 Or run:
 

--- a/content/guides/installing.md
+++ b/content/guides/installing.md
@@ -41,7 +41,7 @@ export KUBECONFIG=<path to kubeconfig>
 
 > [!NOTE] The Desktop App is currently in Developer Preview. You will have to start the CodeZero Daemon using the CLI `czctl start` command. The Desktop App Installer does not install the CLI at this time.
 
-You can download the Desktop App Installer for your platform from our [Desktop App downloads page](https://codezero.io/platform/desktop).
+You can download the Desktop App Installer for your platform from our [Desktop App downloads page](https://codezero.io/tooling/desktop).
 
 We are happy to provide support for macOS and Linux at this time. The CodeZero CLI can be run on Windows using Windows Subsystem for Linux (WSL), but the Desktop App requires a native Mac or Linux operating system.
 

--- a/content/tutorials/desktop-app.md
+++ b/content/tutorials/desktop-app.md
@@ -1,8 +1,8 @@
 # Using the Desktop App
 
-With the [CodeZero Desktop](https://codezero.io/platform/desktop) app you can run commands like Teleport, Intercept, and Mount from your system tray, launch a visual dashboard for the state of your sessions, and view the activity of other collaborators in your cluster.
+With the [CodeZero Desktop](https://codezero.io/tooling/desktop) app you can run commands like Teleport, Intercept, and Mount from your system tray, launch a visual dashboard for the state of your sessions, and view the activity of other collaborators in your cluster.
 
-In this tutorial we are going to install the [CodeZero Desktop](https://codezero.io/platform/desktop) app and use it to run some [Development Profiles](/concepts/profiles.md) containing commands for Teleport and Intercept.
+In this tutorial we are going to install the [CodeZero Desktop](https://codezero.io/tooling/desktop) app and use it to run some [Development Profiles](/concepts/profiles.md) containing commands for Teleport and Intercept.
 
 ## Objectives
 

--- a/content/welcome/overview.md
+++ b/content/welcome/overview.md
@@ -1,6 +1,6 @@
 # Overview
 
-CodeZero is a modern development platform for Kubernetes. Before Kubernetes and Cloud-computing it was possible to write and debug _most_ software on a single developer workstation. As software complexity has grown and organizations have moved to a microservice focused architecture designed to run on clusters of computers, it is no longer feasible to run these applications on a single workstation. This makes developing new features and diagnosing issues challenging.
+CodeZero is for modern development with Kubernetes. Before Kubernetes and Cloud-computing it was possible to write and debug _most_ software on a single developer workstation. As software complexity has grown and organizations have moved to a microservice focused architecture designed to run on clusters of computers, it is no longer feasible to run these applications on a single workstation. This makes developing new features and diagnosing issues challenging.
 
 This documentation is geared towards a technical audience, and we assume you have a working knowledge of Kubernetes.
 


### PR DESCRIPTION
We changed "platform" to "tooling"