### PR TITLE
fix: note about zsh and escaping open parens

### DIFF
--- a/content/tutorials/sample-project.md
+++ b/content/tutorials/sample-project.md
@@ -103,5 +103,8 @@ On macOS, you can access the service using:
 ```bash
 open http://$(kubectl get svc -n sample-project sample-project-frontend --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
+> [!NOTE]
+> For `zsh` users, when pasting the script command into your terminal, the open paren before "kubectl" 
+> may be escaped automatically by zsh.
 
 Congratulations, you are now ready to move on to the [Developing Edge Services](/tutorials/edge.md) tutorial.

--- a/content/tutorials/sample-project.md
+++ b/content/tutorials/sample-project.md
@@ -105,6 +105,6 @@ open http://$(kubectl get svc -n sample-project sample-project-frontend --output
 ```
 > [!NOTE]
 > For `zsh` users, when pasting the script command into your terminal, the open paren before "kubectl" 
-> may be escaped automatically by zsh.
+> may be escaped automatically by zsh. The escape character will need to be removed for the comand to run.
 
 Congratulations, you are now ready to move on to the [Developing Edge Services](/tutorials/edge.md) tutorial.

--- a/content/tutorials/sample-project.md
+++ b/content/tutorials/sample-project.md
@@ -104,7 +104,7 @@ On macOS, you can access the service using:
 open http://$(kubectl get svc -n sample-project sample-project-frontend --output jsonpath='{.status.loadBalancer.ingress[0].ip}')
 ```
 > [!NOTE]
-> For `zsh` users, when pasting the script command into your terminal, the open paren before "kubectl" 
+> For `zsh` users, when pasting the script command into your terminal, the open parenthesis before "kubectl" 
 > may be escaped automatically by zsh. The escape character will need to be removed for the comand to run.
 
 Congratulations, you are now ready to move on to the [Developing Edge Services](/tutorials/edge.md) tutorial.


### PR DESCRIPTION
## Description

In zsh, the command "open http://$(kubectl get svc -n sample-project sample-project-frontend --output jsonpath='{.status.loadBalancer.ingress[0].ip}')" automatically inserts an open paren and the command fails.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update
- [ ] Technical improvement or removal of technical debt. 
- [ ] Minor change: comments, documentation, trivial fixes

## How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration.

- [ ] Unit Tests

Optional:

- [ ] Functional Tests
- [ ] Integration Tests

