### PR TITLE
Update command-line.md - corrected "czctl organization list" usage example plus minor formatting

### DIFF
--- a/docs/references/command-line.md
+++ b/docs/references/command-line.md
@@ -289,13 +289,13 @@ List organizations
 #### Usage
 
 ```bash
-czctl organization clear [flags]
+czctl organization list [flags]
 ```
 
 #### Examples
 
 ```bash
-czctl organization clear --format json
+czctl organization list --format json
 ```
 
 #### Flags
@@ -304,7 +304,7 @@ czctl organization clear --format json
 
 | Flags             | Description                                 |
 | ----------------- | ------------------------------------------- |
-| --format `string` | Output format (text\|json) (default "text") |
+| --format `string` | Output format (text \| json) (default "text") |
 
 </div>
 
@@ -448,7 +448,7 @@ czctl serve list --format json
 
 | Flags             | Description                                 |
 | ----------------- | ------------------------------------------- |
-| --format `string` | Output format (yaml\|json) (default "yaml") |
+| --format `string` | Output format (yaml \| json) (default "yaml") |
 
 </div>
 
@@ -480,7 +480,7 @@ czctl space list --format json
 
 | Flags             | Description                                 |
 | ----------------- | ------------------------------------------- |
-| --format `string` | Output format (text\|json) (default "text") |
+| --format `string` | Output format (text \| json) (default "text") |
 
 </div>
 


### PR DESCRIPTION
corrected "czctl organization list" usage example plus minor formatting 

## Description

1. corrected an error in the "czctl organization list" usage examples (it was accidentally duplicating the "czctl organization clear" usage example
2. updated formatting to make the "output format" help text consistently spaced

