### PR TITLE
chore: replace all install-headless references with brew install

### DIFF
--- a/docs/_fragments/app-install.md
+++ b/docs/_fragments/app-install.md
@@ -1,11 +1,5 @@
 To install Codezero via the command line, run:
 
 ```bash
-curl -L https://releases.codezero.io/install-headless.sh | /bin/bash
+brew install c6o/codezero/codezero
 ```
-
-:::tip
-
-If you want to play around with pre-releases, you can install canary releases using: `curl -L https://releases.codezero.io | /bin/bash -s -- canary`. A word of caution, however, as canary releases have not been fully tested and may cause unexpected behavior.
-
-:::

--- a/docs/_fragments/app-install.md
+++ b/docs/_fragments/app-install.md
@@ -1,5 +1,5 @@
 To install Codezero via the command line, run:
 
 ```bash
-brew install c6o/codezero/codezero
+brew install c6o/tap/codezero
 ```

--- a/docs/_fragments/app-install.md
+++ b/docs/_fragments/app-install.md
@@ -1,5 +1,0 @@
-To install Codezero via the command line, run:
-
-```bash
-brew install c6o/tap/codezero
-```

--- a/docs/_fragments/app-requirements.md
+++ b/docs/_fragments/app-requirements.md
@@ -1,4 +1,0 @@
-Codezero requires:
-
-- MacOS or Ubuntu 18.x+ to run the CLI (`czctl`)
-- `sudo`/`root` permissions on your local system

--- a/docs/guides/installing.mdx
+++ b/docs/guides/installing.mdx
@@ -20,7 +20,7 @@ Codezero's developer tools help in the development and testing of Kubernetes app
 If you are in a headless environment, or don't want to install the Desktop GUI, you can run:
 
 ```bash
-brew install c6o/codezero/codezero
+brew install c6o/tap/codezero
 ```
 
 to install a headless version of the tool, which only includes the `czctl` CLI and background services.

--- a/docs/guides/installing.mdx
+++ b/docs/guides/installing.mdx
@@ -6,15 +6,53 @@ sidebar_position: 4
 
 Codezero's developer tools help in the development and testing of Kubernetes applications through a Command Line Interface (CLI) and a web application.
 
-To install Codezero via the command line, run:
-
-```bash
-brew install c6o/tap/codezero
-```
+From the command-line, use an install script or download and extract a versioned archive file for your operating system to install Codezero.
 
 ## Requirements
 
 Codezero requires:
 
 - MacOS or Ubuntu 18.x+ to run the CLI (`czctl`)
-- `sudo`/`root` permissions on your local system
+- `sudo`/`root`/administrator permissions on your local system
+
+## Homebrew
+
+To install Codezero with [homebrew](https://brew.sh), run:
+
+```bash
+brew install c6o/tap/codezero
+```
+
+## Install without a package manager on macOS or Linux
+
+To install Codezero without a package manager on macOS or Linux:
+
+1. Download the latest version for your OS and CPU architecture type:
+
+| OS    | Arch Type | URL                                                             |
+| ----- | --------- | --------------------------------------------------------------- |
+| macOS | amd64     | https://releases.codezero.io/2.3.3/headless-darwin-amd64.tar.gz |
+| macOS | arm64     | https://releases.codezero.io/2.3.3/headless-darwin-arm64.tar.gz |
+| Linux | amd64     | https://releases.codezero.io/2.3.3/headless-linux-amd64.tar.gz  |
+| Linux | arm64     | https://releases.codezero.io/2.3.3/headless-linux-arm64.tar.gz  |
+
+2. Unzip the file: `tar -xzvf headless-*.tar.gz`
+
+Optionally, install the binary in a location where you can execute it globally (for example, `/usr/local/bin`).
+
+## Install without a package manager on Windows
+
+To install Codezero without a package manager on Windows:
+
+1. Download the latest version for your CPU architecture type:
+
+| Arch Type | URL                                                           |
+| --------- | ------------------------------------------------------------- |
+| amd64     | https://releases.codezero.io/2.3.3/headless-windows-amd64.zip |
+| arm64     | https://releases.codezero.io/2.3.3/headless-windows-arm64.zip |
+
+2. Unzip the file.
+
+3. Add the path to the unzipped `czctl.exe` and `czdaemon.exe` files to your `Path` environment variable.
+   To learn how to update environment variables, see the
+   [Microsoft PowerShell documentation](https://learn.microsoft.com/en-us/powershell/module/microsoft.powershell.core/about/about_environment_variables?view=powershell-7.3#saving-changes-to-environment-variables).

--- a/docs/guides/installing.mdx
+++ b/docs/guides/installing.mdx
@@ -20,21 +20,7 @@ Codezero's developer tools help in the development and testing of Kubernetes app
 If you are in a headless environment, or don't want to install the Desktop GUI, you can run:
 
 ```bash
-curl -L https://releases.codezero.io/install-headless.sh | /bin/bash
+brew install c6o/codezero/codezero
 ```
 
 to install a headless version of the tool, which only includes the `czctl` CLI and background services.
-
-### Installing a Specific Version
-
-If you want to install a specific version of our CLI or reinstall an older you can run:
-
-```bash
-curl -L https://releases.codezero.io/install-headless.sh | /bin/bash -s -- 1.7.0
-```
-
-:::caution
-
-Older releases might contain bugs that have since been fixed. We always recomend running the lastest version of both our CLI and Desktop products. Additonally, before opening any bug reports, please update the latest stable release. If you still encouter an issue, please report it on our public roadmap.
-
-:::

--- a/docs/guides/installing.mdx
+++ b/docs/guides/installing.mdx
@@ -2,25 +2,19 @@
 sidebar_position: 4
 ---
 
-import AppInstall from '../_fragments/app-install.md'
-import AppRequirements from '../_fragments/app-requirements.md'
-
 # Installing Local Agent
 
 Codezero's developer tools help in the development and testing of Kubernetes applications through a Command Line Interface (CLI) and a web application.
 
-<AppInstall />
-
-## Requirements
-
-<AppRequirements />
-
-## Install Only the Codezero CLI
-
-If you are in a headless environment, or don't want to install the Desktop GUI, you can run:
+To install Codezero via the command line, run:
 
 ```bash
 brew install c6o/tap/codezero
 ```
 
-to install a headless version of the tool, which only includes the `czctl` CLI and background services.
+## Requirements
+
+Codezero requires:
+
+- MacOS or Ubuntu 18.x+ to run the CLI (`czctl`)
+- `sudo`/`root` permissions on your local system

--- a/versioned_docs/version-1.9.0/guides/installing.mdx
+++ b/versioned_docs/version-1.9.0/guides/installing.mdx
@@ -20,24 +20,10 @@ Codezero's developer tools help in the development and testing of Kubernetes app
 If you are in a headless environment, or don't want to install the Desktop GUI, you can run:
 
 ```bash
-curl -sL https://releases.codezero.io/install-headless.sh | /bin/bash
+brew install c6o/codezero/codezero
 ```
 
 to install a headless version of the tool, which only includes the `czctl` CLI and background services.
-
-### Installing a Specific Version
-
-If you want to install a specific version of our CLI or reinstall an older you can run:
-
-```bash
-curl -sL https://releases.codezero.io/install-headless.sh | /bin/bash -s -- 1.6.0
-```
-
-:::caution
-
-Older releases might contain bugs that have since been fixed. We always recomend running the lastest version of both our CLI and Desktop products. Additonally, before opening any bug reports, please update the latest stable release. If you still encouter an issue, please report it on our public roadmap.
-
-:::
 
 ## Canary vs Stable Releases
 

--- a/versioned_docs/version-1.9.0/guides/installing.mdx
+++ b/versioned_docs/version-1.9.0/guides/installing.mdx
@@ -25,6 +25,20 @@ curl -sL https://releases.codezero.io/install-headless.sh | /bin/bash
 
 to install a headless version of the tool, which only includes the `czctl` CLI and background services.
 
+### Installing a Specific Version
+
+If you want to install a specific version of our CLI or reinstall an older you can run:
+
+```bash
+curl -sL https://releases.codezero.io/install-headless.sh | /bin/bash -s -- 1.6.0
+```
+
+:::caution
+
+Older releases might contain bugs that have since been fixed. We always recomend running the lastest version of both our CLI and Desktop products. Additonally, before opening any bug reports, please update the latest stable release. If you still encouter an issue, please report it on our public roadmap.
+
+:::
+
 ## Canary vs Stable Releases
 
 We are constantly adding new features and addressing issues. As a result, we strive to have a fairly rapid release of our tools. There are times when we want to get your feedback on new features or issues. This is particularly important when there are scenarios that are difficult for us to reproduce. For this reason, we have split our releases into Stable and Canary releases.

--- a/versioned_docs/version-1.9.0/guides/installing.mdx
+++ b/versioned_docs/version-1.9.0/guides/installing.mdx
@@ -20,7 +20,7 @@ Codezero's developer tools help in the development and testing of Kubernetes app
 If you are in a headless environment, or don't want to install the Desktop GUI, you can run:
 
 ```bash
-brew install c6o/codezero/codezero
+curl -sL https://releases.codezero.io/install-headless.sh | /bin/bash
 ```
 
 to install a headless version of the tool, which only includes the `czctl` CLI and background services.


### PR DESCRIPTION
# Not merge it yet

We should merge it whenever we want to make public the new way of installing codezero 

```
brew install c6o/codezero/codezero
```

There is a script at https://storage.googleapis.com/c6o-releases/uninstall.sh which should be used by clients who have installed codezero using the "now old" install-headless.sh script. 
This script cleans up the binaries that have been installed by using the "now old" install-headless.sh script.

Ref: https://github.com/c6o/codezero/pull/1443