### PR TITLE
include annotation to do https healthchecks

### DIFF
--- a/docs/getting-started/teamspace-setup.md
+++ b/docs/getting-started/teamspace-setup.md
@@ -49,6 +49,7 @@ spaceagent:
             service.beta.kubernetes.io/aws-load-balancer-type: "external"
             service.beta.kubernetes.io/aws-load-balancer-nlb-target-type: "ip"
             service.beta.kubernetes.io/aws-load-balancer-scheme: "internet-facing"
+            service.beta.kubernetes.io/aws-load-balancer-healthcheck-protocol: "https"
 ```
 
 </TabItem>


### PR DESCRIPTION
## Description

using https as health check protocol fixes constant TLS handshake errors

```
{"time":"2025-02-06T01:38:27.082385741Z","level":"INFO","msg":"http: TLS handshake error from 192.168.38.19:19264: EOF"}
```

